### PR TITLE
Fix broken link in getting-started

### DIFF
--- a/src/getting-started/readme.md
+++ b/src/getting-started/readme.md
@@ -3,4 +3,4 @@
 To get started with Foundry, install the toolchain and set up your first project.
 
 - [Installation](./installation.md)
-- [First steps with Foundry](./first-steps-with-foundry.md)
+- [First steps with Foundry](./first-steps.md)


### PR DESCRIPTION
I think this fixes the 404 link in the getting started page not pointing correctly to `first-steps.md`