### PR TITLE
docs: add forge-std's deployCode

### DIFF
--- a/src/forge/writing-tests.md
+++ b/src/forge/writing-tests.md
@@ -65,5 +65,9 @@ Forge uses the following keywords in tests:
 It is possible to use other testing libraries or roll your own. For example, if you find yourself lacking a special type of assertion, you could extend `ds-test`.
 
 > 📚 **Reference**
-> 
+>
 > See the [`ds-test` Reference](../reference/ds-test.md) for a complete overview of the logging functionality and assertions in `ds-test`.
+
+> 💡 **Tip**
+>
+> Use the [`getCode`](../reference/cheatcodes.md#getcode) cheatcode to deploy contracts with incompatible Solidity versions.

--- a/src/reference/cheatcodes.md
+++ b/src/reference/cheatcodes.md
@@ -460,7 +460,7 @@ If a match is found, then `retdata` is returned from the call.
 Mocked calls are in effect until [`clearMockedCalls`](#clearmockedcalls) is called.
 
 > 💬 **Note**
-> 
+>
 > Calls to mocked addresses may revert if there is no code on the address.
 > This is because Solidity inserts an `extcodesize` check before some contract calls.
 >
@@ -536,6 +536,18 @@ function getCode(string calldata) external returns (bytes memory);
 ```
 
 Returns the bytecode for a contract in the project given the path to the contract.
+
+If you'd like to use getCode to deploy a contract's bytecode, you can use [forge-std](https://github.com/brockelmore/forge-std)'s `deployCode` helper. In your test file:
+
+```solidity
+    function testDeployCode() public {
+        // deployCode takes a string argument for the contract to deploy
+        // and optionally a bytes argument for any arguments that should
+        // be passed to your contract's constructor
+        address deployed = deployCode("StdCheats.t.sol:StdCheatsTest", bytes(""));
+        ...
+    }
+```
 
 <br>
 

--- a/src/reference/cheatcodes.md
+++ b/src/reference/cheatcodes.md
@@ -537,7 +537,25 @@ function getCode(string calldata) external returns (bytes memory);
 
 Returns the bytecode for a contract in the project given the path to the contract.
 
-If you'd like to use getCode to deploy a contract's bytecode, you can use [forge-std](https://github.com/brockelmore/forge-std)'s `deployCode` helper. In your test file:
+The calldata parameter can either be in the form `ContractFile.sol` (if the filename and contract name are the same), `ContractFile.sol:ContractName`, or `./path/to/artifact.json`
+
+#### Example
+
+```solidity
+MyContract myContract = new MyContract(arg1, arg2);
+
+// Let's do the same thing with `getCode`
+bytes memory args = abi.encode(arg1, arg2);
+bytes memory bytecode = abi.encodePacked(cheats.getCode("MyContract.sol:MyContract"), args);
+address anotherAddress;
+assembly {
+    anotherAddress := create(0, add(bytecode, 0x20), mload(bytecode))
+}
+
+assertEq0(address(myContract).code, anotherAddress.code); // [PASS]
+```
+
+If you'd like to use getCode to deploy a contract's bytecode, you can also use [forge-std](https://github.com/brockelmore/forge-std)'s `deployCode` helper. In your test file:
 
 ```solidity
     function testDeployCode() public {


### PR DESCRIPTION
## Description

Add docs for https://github.com/brockelmore/forge-std/blob/master/src/stdlib.sol#L78-L88

## Motivation

<img width="927" alt="Screen Shot 2022-03-02 at 1 17 45 AM" src="https://user-images.githubusercontent.com/3699047/156306289-3392ff69-be2f-4ea5-979b-e5db2c091d5c.png">

## Screenshot

### [reference/cheatcodes](https://onbjerg.github.io/foundry-book/reference/cheatcodes.html#getcode)

<img width="818" alt="Screen Shot 2022-03-02 at 10 59 36 PM" src="https://user-images.githubusercontent.com/3699047/156494369-89661f2f-2490-41d0-b265-d9c91ac07abf.png">

### [forge/writing-tests](https://onbjerg.github.io/foundry-book/forge/writing-tests.html)

<img width="777" alt="Screen Shot 2022-03-02 at 10 59 25 PM" src="https://user-images.githubusercontent.com/3699047/156494422-922e3f9c-d47d-46ea-bae4-f01ddb381e1a.png">



