### PR TITLE
docs: add reference to Awesome Foundry repo

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -32,3 +32,4 @@ More guides on various topics.
 
 References on Foundry and Foundry-related tools.
 
+> You can also check out [Awesome Foundry](https://github.com/crisgarner/awesome-foundry), a curated list of awesome Foundry resources, tutorials, tools and libraries!


### PR DESCRIPTION
This Pull Request adds a link to the Awesome Foundry GitHub repo by Cris Garner. Closes #25 