### PR TITLE
Fix: Cheatcodes Interface whitespace

### DIFF
--- a/src/reference/cheatcodes.md
+++ b/src/reference/cheatcodes.md
@@ -10,62 +10,87 @@ This is a complete overview of all the available cheatcodes. For detailed descri
 
 ```solidity
 interface CheatCodes {
-    // Set block.timestamp
+
     function warp(uint256) external;
-    // Set block.number
+    // Set block.timestamp
+
     function roll(uint256) external;
-    // Set block.basefee
+    // Set block.number
+
     function fee(uint256) external;
-    // Loads a storage slot from an address
+    // Set block.basefee
+
     function load(address account, bytes32 slot) external returns (bytes32);
-    // Stores a value to an address' storage slot
+    // Loads a storage slot from an address
+
     function store(address account, bytes32 slot, bytes32 value) external;
-    // Signs data
+    // Stores a value to an address' storage slot
+
     function sign(uint256 privateKey, bytes32 digest) external returns (uint8 v, bytes32 r, bytes32 s);
-    // Computes address for a given private key
+    // Signs data
+
     function addr(uint256 privateKey) external returns (address);
-    // Performs a foreign function call via terminal
+    // Computes address for a given private key
+
     function ffi(string[] calldata) external returns (bytes memory);
-    // Sets the *next* call's msg.sender to be the input address
+    // Performs a foreign function call via terminal
+
     function prank(address) external;
-    // Sets all subsequent calls' msg.sender to be the input address until `stopPrank` is called
+    // Sets the *next* call's msg.sender to be the input address
+
     function startPrank(address) external;
-    // Sets the *next* call's msg.sender to be the input address, and the tx.origin to be the second input
+    // Sets all subsequent calls' msg.sender to be the input address until `stopPrank` is called
+
     function prank(address, address) external;
-    // Sets all subsequent calls' msg.sender to be the input address until `stopPrank` is called, and the tx.origin to be the second input
+    // Sets the *next* call's msg.sender to be the input address, and the tx.origin to be the second input
+
     function startPrank(address, address) external;
-    // Resets subsequent calls' msg.sender to be `address(this)`
+    // Sets all subsequent calls' msg.sender to be the input address until `stopPrank` is called, and the tx.origin to be the second input
+
     function stopPrank() external;
-    // Sets an address' balance
+    // Resets subsequent calls' msg.sender to be `address(this)`
+
     function deal(address who, uint256 newBalance) external;
-    // Sets an address' code
+    // Sets an address' balance
+
     function etch(address who, bytes calldata code) external;
-    // Expects an error on next call
+    // Sets an address' code
+
     function expectRevert(bytes calldata) external;
     function expectRevert(bytes4) external;
-    // Record all storage reads and writes
+    // Expects an error on next call
+
     function record() external;
-    // Gets all accessed reads and write slot from a recording session, for a given address
+    // Record all storage reads and writes
+
     function accesses(address) external returns (bytes32[] memory reads, bytes32[] memory writes);
+    // Gets all accessed reads and write slot from a recording session, for a given address
+
+    function expectEmit(bool, bool, bool, bool) external;
     // Prepare an expected log with (bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData).
     // Call this function, then emit an event, then call a function. Internally after the call, we check if
     // logs were emitted in the expected order with the expected topics and data (as specified by the booleans)
-    function expectEmit(bool, bool, bool, bool) external;
+
+    function mockCall(address, bytes calldata, bytes calldata) external;
     // Mocks a call to an address, returning specified data.
     // Calldata can either be strict or a partial match, e.g. if you only
     // pass a Solidity selector to the expected calldata, then the entire Solidity
     // function will be mocked.
-    function mockCall(address, bytes calldata, bytes calldata) external;
-    // Clears all mocked calls
+
     function clearMockedCalls() external;
+    // Clears all mocked calls
+
+    function expectCall(address, bytes calldata) external;
     // Expect a call to an address with the specified calldata.
     // Calldata can either be strict or a partial match
-    function expectCall(address, bytes calldata) external;
+
     function getCode(string calldata) external returns (bytes memory);
-    // Label an address in test traces
+
     function label(address addr, string label) external;
-    // When fuzzing, generate new inputs if conditional not met
+    // Label an address in test traces
+
     function assume(bool) external;
+    // When fuzzing, generate new inputs if conditional not met
 }
 ```
 

--- a/src/reference/cheatcodes.md
+++ b/src/reference/cheatcodes.md
@@ -85,6 +85,7 @@ interface CheatCodes {
     // Calldata can either be strict or a partial match
 
     function getCode(string calldata) external returns (bytes memory);
+    // Gets the bytecode for a contract in the project given the path to the contract.
 
     function label(address addr, string label) external;
     // Label an address in test traces

--- a/src/reference/cheatcodes.md
+++ b/src/reference/cheatcodes.md
@@ -195,7 +195,7 @@ function sign(uint256 privateKey, bytes32 digest) external returns (uint8 v, byt
 
 Signs a digest `digest` with private key `privateKey`, returning `(v, r, s)`.
 
-This is useful for testing functions that take signed data and performs an `ecrecover` to verify the signer.
+This is useful for testing functions that take signed data and perform an `ecrecover` to verify the signer.
 ##### Example
 ```solidity
 address alice = cheats.addr(1);


### PR DESCRIPTION
I refer to the Cheatcodes reference page often and I believe the whitespace (or lack thereof) on the [Cheatcodes Interface section](https://onbjerg.github.io/foundry-book/reference/cheatcodes.html#cheatcodes-interface) could be improved.

Summary of proposed changes:
1. I initially just wanted to add a blank line between each function, but after doing that I thought it looked better with the function definition comment was below the function sig line.
2. In performing this, I noticed a definition comment was missing for `getCode()` so I added it
3. My grammar checker also caught a very minor grammar fix
