### PR TITLE
docs: label name param data location = calldata

### DIFF
--- a/src/reference/cheatcodes.md
+++ b/src/reference/cheatcodes.md
@@ -87,7 +87,7 @@ interface CheatCodes {
     function getCode(string calldata) external returns (bytes memory);
     // Gets the bytecode for a contract in the project given the path to the contract.
 
-    function label(address addr, string label) external;
+    function label(address addr, string calldata label) external;
     // Label an address in test traces
 
     function assume(bool) external;


### PR DESCRIPTION
label() is missing data location for name param elicits:
![Screen Shot 2022-03-11 at 11 36 02 AM](https://user-images.githubusercontent.com/71567643/157946321-2bfe1353-6dbd-4e68-85a3-67ad5ccdc8fb.png)
