### PR TITLE
Update expectEmit reference

### DIFF
--- a/src/reference/cheatcodes.md
+++ b/src/reference/cheatcodes.md
@@ -425,9 +425,14 @@ This cheat code is used to assert that certain logs are emitted on the next call
 2. Emit the event we are supposed to see after the next call.
 3. Perform the call.
 
+If the event is not available in the scope (e.g because we use some Interface or external smart contract), we can define the event ourselves with an identical event signature. 
+
+
 For example:
 
 ```solidity
+event Transfer(address indexed from, address indexed to, uint256 amount);
+
 function testERC20EmitsTransfer() public {
   // Only `src` and `dst` are indexed in ERC20's `Transfer` event,
   // so we only check topic 0 and 1, as well as the data (`amount`).
@@ -461,14 +466,15 @@ function testERC20EmitsTransfer() public {
 
 <br>
 
-We can also assert that multiple events are emitted in a single call. However this currently requires that we only test event emission and not topics or data. For example:
+We can also assert that multiple events are emitted in a single call. 
+For example:
 
 ```solidity
 function testERC20EmitsBatchTransfer() public {
   // We declare multiple expected transfer events
   for (uint256 i = 0; i < users.length; i++) {
     // Each parameter must be set to false for batch event emission tests to work.
-    cheats.expectEmit(false, false, false, false);
+    cheats.expectEmit(true, true, true, true);
     emit Transfer(address(this), users[i], 10);
   }
 

--- a/src/reference/cheatcodes.md
+++ b/src/reference/cheatcodes.md
@@ -467,8 +467,7 @@ function testERC20EmitsTransfer() public {
 
 <br>
 
-We can also assert that multiple events are emitted in a single call. 
-For example:
+We can also assert that multiple events are emitted in a single call. For example:
 
 ```solidity
 function testERC20EmitsBatchTransfer() public {

--- a/src/reference/cheatcodes.md
+++ b/src/reference/cheatcodes.md
@@ -427,6 +427,7 @@ This cheat code is used to assert that certain logs are emitted on the next call
 
 If the event is not available in the scope (e.g because we use some Interface or external smart contract), we can define the event ourselves with an identical event signature. 
 
+Currently, the cheatcode does not check the origin contract of the event, but simply that it was emitted during that call.
 
 For example:
 

--- a/src/reference/cheatcodes.md
+++ b/src/reference/cheatcodes.md
@@ -425,7 +425,7 @@ This cheat code is used to assert that certain logs are emitted on the next call
 2. Emit the event we are supposed to see after the next call.
 3. Perform the call.
 
-If the event is not available in the scope (e.g because we use some Interface or external smart contract), we can define the event ourselves with an identical event signature. 
+If the event is not available in the current scope (e.g because we are using an interface, or an external smart contract), we can define the event ourselves with an identical event signature. 
 
 Currently, the cheatcode does not check the origin contract of the event, but simply that it was emitted during that call.
 

--- a/src/reference/cheatcodes.md
+++ b/src/reference/cheatcodes.md
@@ -427,7 +427,7 @@ This cheat code is used to assert that certain logs are emitted on the next call
 
 If the event is not available in the current scope (e.g because we are using an interface, or an external smart contract), we can define the event ourselves with an identical event signature. 
 
-Currently, the cheatcode does not check the origin contract of the event, but simply that it was emitted during that call.
+The cheatcode does not check the origin of the event, but simply that it was emitted during that call.
 
 For example:
 

--- a/src/reference/cheatcodes.md
+++ b/src/reference/cheatcodes.md
@@ -473,13 +473,11 @@ We can also assert that multiple events are emitted in a single call. For exampl
 function testERC20EmitsBatchTransfer() public {
   // We declare multiple expected transfer events
   for (uint256 i = 0; i < users.length; i++) {
-    // Each parameter must be set to false for batch event emission tests to work.
     cheats.expectEmit(true, true, true, true);
     emit Transfer(address(this), users[i], 10);
   }
 
   // We also expect a custom `BatchTransfer(uint256 numberOfTransfers)` event.
-  // Again, each expectEmit parameter must be false.
   cheats.expectEmit(false, false, false, false);
   emit BatchTransfer(users.length);
 


### PR DESCRIPTION
- Remove requirement for not checking values in batched events
- Add best practice comment on defining the event ourselves if it's not in-scope.

This is based on what I learned in the recent uniswap v3-periphery migration