### PR TITLE
Fix checksum for test contract address

### DIFF
--- a/src/forge/writing-tests.md
+++ b/src/forge/writing-tests.md
@@ -71,7 +71,7 @@ Forge uses the following keywords in tests:
 
 You may choose to use `constructor` for certain logic instead of `setUp`. Since `setUp` is invoked before each test case is run, it is most suitable for "resetting" the arrangement part of your tests. If you do not want certain things to be reset every time a test is ran, use `constructor` instead for those.
 
-Tests are deployed to `0xb4c79dab8f259c7aee6e5b2aa729821864227e84`. If you deploy a contract within your test, then `0xb4c...7e84` will be its deployer. If the contract deployed within a test gives special permissions to its deployer, such as `Ownable.sol`'s `onlyOwner` modifier, then the test contract `0xb4c...7e84` will have those permissions.
+Tests are deployed to `0xb4c79daB8f259C7Aee6E5b2Aa729821864227e84`. If you deploy a contract within your test, then `0xb4c...7e84` will be its deployer. If the contract deployed within a test gives special permissions to its deployer, such as `Ownable.sol`'s `onlyOwner` modifier, then the test contract `0xb4c...7e84` will have those permissions.
 
 It is possible to use other testing libraries or roll your own. For example, if you find yourself lacking a special type of assertion, you could extend `ds-test`.
 


### PR DESCRIPTION
### Description
Fix checksum for test contract address. You can verify this checksum by navigating to https://etherscan.io/address/0xb4c79dab8f259c7aee6e5b2aa729821864227e84 and comparing the address (case-sensitive) that Etherscan displays with the address casing in this PR.

### Motivation
<img width="1248" alt="Screen Shot 2022-03-20 at 8 12 30 PM" src="https://user-images.githubusercontent.com/3699047/159192152-9e97b7ec-7206-49a9-bec5-9f463919e5b4.png">