### PR TITLE
update broken incremental adoption links in readme

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -24,7 +24,7 @@ Learn how to use `cast` to interact with smart contracts, send transactions, and
 
 More guides on various topics.
 
-- [Incremental Adoption](guides/incremental-adoption.md)
+- [Incremental Adoption]()
 - [Integrating with VSCode](guides/vscode.md)
 - [Shell Autocompletion](guides/shell-autocompletion.md)
 

--- a/src/guides/README.md
+++ b/src/guides/README.md
@@ -2,6 +2,6 @@
 
 This chapter contains additional guides on various topics related to Foundry.
 
-- [Incremental Adoption](./incremental-adoption.md)
+- [Incremental Adoption]()
 - [Integrating with VSCode](./vscode.md)
 - [Shell Autocompletion](./shell-autocompletion.md)


### PR DESCRIPTION
Noticed that incremental adoption readme was missing so I updated the links where necessary.