### PR TITLE
Add calldata to label function signature

### DIFF
--- a/src/reference/cheatcodes.md
+++ b/src/reference/cheatcodes.md
@@ -425,7 +425,7 @@ This cheat code is used to assert that certain logs are emitted on the next call
 2. Emit the event we are supposed to see after the next call.
 3. Perform the call.
 
-If the event is not available in the current scope (e.g because we are using an interface, or an external smart contract), we can define the event ourselves with an identical event signature. 
+If the event is not available in the current scope (e.g because we are using an interface, or an external smart contract), we can define the event ourselves with an identical event signature.
 
 The cheatcode does not check the origin of the event, but simply that it was emitted during that call.
 
@@ -617,7 +617,7 @@ If you'd like to use getCode to deploy a contract's bytecode, you can also use [
 #### `label`
 
 ```solidity
-function label(address addr, string label) external;
+function label(address addr, string calldata label) external;
 ```
 
 Sets a label `label` for `addr` in test traces.


### PR DESCRIPTION
Fixes

<img width="1106" alt="Screen Shot 2022-03-21 at 11 05 47 PM" src="https://user-images.githubusercontent.com/3699047/159400324-81c0fe4a-2c99-4e57-9d87-56b2173fcaa0.png">

Note this function signature already includes `calldate` [here](https://github.com/onbjerg/foundry-book/blob/bcc23b30a453692240f7f38491f603064f24daa1/src/reference/cheatcodes.md?plain=1#L90)
