### PR TITLE
fix: remove misc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,8 +38,6 @@ Feel free to contribute changes to the book by opening a pull request - anything
 
 When your pull request is open, other contributors will take a look and may request changes. Do not be discouraged!
 
-See [Writing Style](#writing-style) (below).
-
 ### Getting recognition
 
 If your pull request is merged, or your issue was addressed, feel free to ping @all-contributors to be added to the README. More information here: https://allcontributors.org/docs/en/bot/overview
@@ -47,63 +45,9 @@ If your pull request is merged, or your issue was addressed, feel free to ping @
 ### Writing Style
 This section documents a few standards for writing used throughout the book.
 
-- Use relative links instead of absolute links:
-
-```text
-.
-├── current-dir
-│   └── you-are-here.md
-└── target-dir
-    └── target-file.md
-
-... link like [this](../target-dir/target-file.md)
-...  not like [this](/target-dir/target-file.md)
-```
 - Provide console output along with commands, in this format:
 
 ```bash
 $ command --goes "here"
 Output goes here
 ```
-
-- Use level 2 heading for section titles. Use a heading whenever a subject should be linkable:
-
-```text
-## Section title
-...
-### Subject
-...
-#### Example
-...
-```
-
-- Feel free to use callouts where appropriate:
-
-```text
-> ℹ️ **Information**
->
-> Provide additional information. Useful when many things share the same property but you don't want to document it for every one of them, so you mention it at the end.
-```
-
-```
-> 💬 **Note**
->
-> Add a author's note. Sometimes you may want to add a comment in a tone different than the one in the book, to explain or add context as an author.
-```
-
-```
-> 📚 **Reference**
->
-> When a section teaches a subject that also has [reference docs](../reference/subject.md), use this callout at the bottom of the page.
-```
-```
-> 💡 **Tip**
->
-> When it is perfect time to inform a reader about something, but it's only loosely related to the section, use this callout at the bottom of the page.
-```
-
-- Add new sections (files) to [`SUMMARY.md`](src/SUMMARY.md) and to the corresponding local summary:
-  - Forge Guide [`README.md`](src/forge/README.md)
-  - Cast Guide [`README.md`](src/cast/README.md)
-  - Additional Guides [`README.md`](src/guides/README.md)
-  - Reference [`README.md`](src/reference/README.md)

--- a/src/README.md
+++ b/src/README.md
@@ -1,4 +1,4 @@
-![Foundry Banner](images/foundry-banner.png)
+<img src="images/foundry-banner.png" style="border-radius: 20px">
 
 Foundry is a smart contract development toolchain. Foundry manages your dependencies, compiles your project, runs tests, deploys, and lets you interact with the chain from the command-line.
 
@@ -24,7 +24,7 @@ The overview will give you all you need to know about how to use `forge` to deve
 
 Learn how to use `cast` to interact with smart contracts, send transactions, and get chain data from the command-line.
 
-**[Configuration](config)**
+**Configuration**
 
 Guides on configuring Foundry.
 

--- a/src/forge/writing-tests.md
+++ b/src/forge/writing-tests.md
@@ -69,8 +69,6 @@ Forge uses the following keywords in tests:
     ```
 <br>
 
-You may choose to use `constructor` for certain logic instead of `setUp`. Since `setUp` is invoked before each test case is run, it is most suitable for "resetting" the arrangement part of your tests. If you do not want certain things to be reset every time a test is ran, use `constructor` instead for those.
-
 Tests are deployed to `0xb4c79daB8f259C7Aee6E5b2Aa729821864227e84`. If you deploy a contract within your test, then `0xb4c...7e84` will be its deployer. If the contract deployed within a test gives special permissions to its deployer, such as `Ownable.sol`'s `onlyOwner` modifier, then the test contract `0xb4c...7e84` will have those permissions.
 
 It is possible to use other testing libraries or roll your own. For example, if you find yourself lacking a special type of assertion, you could extend `ds-test`.


### PR DESCRIPTION
- Remove a paragraph about using `setUp` vs `constructor` in `Writing Tests`, which was based on my own misunderstanding.
- Also, took this chance to  remove some writing style guidelines as to not micromanage contributors.