### PR TITLE
Fix incorrect type on return value of address().code in the 'etch' ch…

### DIFF
--- a/src/reference/cheatcodes.md
+++ b/src/reference/cheatcodes.md
@@ -331,7 +331,7 @@ function etch(address who, bytes calldata code) external;
 Sets the bytecode of an address `who` to `code`.
 ##### Example
 ```solidity
-address code = address(awesomeContract).code;
+bytes memory code = address(awesomeContract).code;
 address targetAddr = address(1);
 cheats.etch(targetAddr, code);
 log_bytes(address(targetAddr).code); // 0x6080604052348015610010...


### PR DESCRIPTION
…eat code example

Etch cheat code example incorrectly had the return type as address instead of bytes