### PR TITLE
fix wrong default number in config

### DIFF
--- a/src/reference/config.md
+++ b/src/reference/config.md
@@ -250,7 +250,7 @@ The maximum number of individual inputs that may be rejected before the test as 
 ##### `fuzz_max_global_rejects`
 
 - Type: integer
-- Default: 10234
+- Default: 1024
 - Environment: `FOUNDRY_FUZZ_RUNS`
 
 The maximum number of combined inputs that may be rejected before the test as a whole aborts.


### PR DESCRIPTION
I fat-fingered this in https://github.com/onbjerg/foundry-book/pull/91

Docs confirming this is the correct default: https://docs.rs/proptest/latest/proptest/test_runner/struct.Config.html#structfield.max_local_rejects