### PR TITLE
Add UNLICENSED SDPX identifier

### DIFF
--- a/src/forge/cheatcodes.md
+++ b/src/forge/cheatcodes.md
@@ -7,6 +7,7 @@ Cheatcodes allow you to change the block number, your identity, and more. They a
 Let's write a test for a smart contract that is only callable by its owner.
 
 ```solidity
+// SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 
 contract OwnerUpOnly {

--- a/src/forge/deploying.md
+++ b/src/forge/deploying.md
@@ -21,6 +21,7 @@ Solidity files may contain multiple contracts. `:MyContract` above specifies whi
 Use the `--constructor-args` flag to pass arguments to the constructor:
 
 ```solidity
+// SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 import {ERC20} from "solmate/tokens/ERC20.sol";
 

--- a/src/forge/fuzz-testing.md
+++ b/src/forge/fuzz-testing.md
@@ -7,6 +7,7 @@ Property-based testing is a way of testing general behaviors as opposed to isola
 Let's examine what that means by writing a unit test, finding the general property we are testing for, and converting it to a property-based test instead:
 
 ```solidity
+// SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 
 contract Safe {

--- a/src/tutorials/solmate-nft.md
+++ b/src/tutorials/solmate-nft.md
@@ -91,6 +91,7 @@ cast call --rpc-url=$RPC_URL --private-key=$PRIVATE_KEY <contractAddress> "owner
 Let's extend our NFT by adding metadata to represent the content of our NFTs, as well as set a minting price, a maximum supply and the possibility to withdraw the collected proceeds from minting. To follow along you can replace your current NFT contract with the code snippet below:
 
 ```solidity
+// SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.10;
 
 import "solmate/tokens/ERC721.sol";


### PR DESCRIPTION
Since v0.6.8, the Solidity compiler started throwing the following warning when an SPDX identifier is missing from a contract:

> SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.

Since the Foundry Book should not decide on behalf of the end users what license to use, I set the SPDX to [UNLICENSED](https://docs.soliditylang.org/en/v0.8.13/layout-of-source-files.html#spdx-license-identifier).