### PR TITLE
Foundry and Docker Section

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -51,6 +51,7 @@
 # Tutorials
 
 - [Creating an NFT with Solmate](./tutorials/solmate-nft.md)
+- [Dockerizing a Foundry project](./tutorials/dockerize-solmate-nft.md)
 - [Incremental Adoption]()
 
 # References

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -51,7 +51,7 @@
 # Tutorials
 
 - [Creating an NFT with Solmate](./tutorials/solmate-nft.md)
-- [Dockerizing a Foundry project](./tutorials/dockerize-solmate-nft.md)
+- [Docker and Foundry](./tutorials/foundry-docker.md)
 - [Incremental Adoption]()
 
 # References

--- a/src/getting-started/installation.md
+++ b/src/getting-started/installation.md
@@ -42,27 +42,16 @@ After this, run the following to build Foundry from source:
 cargo install --git https://github.com/gakonst/foundry --bins --locked
 ```
 
-### Using within Docker
+### Using with Docker
 
 Foundry can also be used entirely within a Docker container. If you don't have it, Docker can be installed directly from [Docker's website](https://docs.docker.com/get-docker/)
 
-Once Docker is downloaded and running, you can start an interactive container using the latest image published by Foundry:
+Once installed, you can download the latest release by running:  
 ```sh
-docker run -it --entrypoint /bin/sh ghcr.io/gakonst/foundry:latest
-/ $> forge --help
-forge 0.2.0 (c000ace 2022-03-27T19:44:10.774333400+00:00)
-Build, test, fuzz, formally verify, debug & deploy solidity contracts.
-
-USAGE:
-    forge <SUBCOMMAND>
-
-OPTIONS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-...
+docker pull ghcr.io/gakonst/foundry:latest
 ```
 It is also possible to build the docker image locally. From the Foundry repository, run:
 ```sh
 docker build -t foundry .
 ```
-##### Note: Some machines (including those with M1 chips) may be unable to build the docker image locally. This is a known issue.
+> Note: Some machines (including those with M1 chips) may be unable to build the docker image locally. This is a known issue.

--- a/src/getting-started/installation.md
+++ b/src/getting-started/installation.md
@@ -41,3 +41,28 @@ After this, run the following to build Foundry from source:
 ```sh
 cargo install --git https://github.com/gakonst/foundry --bins --locked
 ```
+
+### Using within Docker
+
+Foundry can also be used entirely within a Docker container. If you don't have it, Docker can be installed directly from [Docker's website](https://docs.docker.com/get-docker/)
+
+Once Docker is downloaded and running, you can start an interactive container using the latest image published by Foundry:
+```sh
+docker run -it --entrypoint /bin/sh ghcr.io/gakonst/foundry:latest
+/ $> forge --help
+forge 0.2.0 (c000ace 2022-03-27T19:44:10.774333400+00:00)
+Build, test, fuzz, formally verify, debug & deploy solidity contracts.
+
+USAGE:
+    forge <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+...
+```
+It is also possible to build the docker image locally. From the Foundry repository, run:
+```sh
+docker build -t foundry .
+```
+##### Note: Some machines (including those with M1 chips) may be unable to build the docker image locally. This is a known issue.

--- a/src/tutorials/dockerize-solmate-nft.md
+++ b/src/tutorials/dockerize-solmate-nft.md
@@ -1,4 +1,0 @@
-## Dockerizing a Foundry project
-
-This tutorial builds off of the [solmate nft](./solmate-nft.md) tutorial. If you haven't completed that tutorial yet, start with it first. Alternatively, if you have some familiarity with Docker and Solidity, you can use your own existing project and adjust accordingly.
-

--- a/src/tutorials/dockerize-solmate-nft.md
+++ b/src/tutorials/dockerize-solmate-nft.md
@@ -1,0 +1,4 @@
+## Dockerizing a Foundry project
+
+This tutorial builds off of the [solmate nft](./solmate-nft.md) tutorial. If you haven't completed that tutorial yet, start with it first. Alternatively, if you have some familiarity with Docker and Solidity, you can use your own existing project and adjust accordingly.
+

--- a/src/tutorials/foundry-docker.md
+++ b/src/tutorials/foundry-docker.md
@@ -1,0 +1,165 @@
+# Dockerizing a Foundry project
+
+This tutorial shows you how to build, test, and deploy a smart contract using Foundry's Docker image. It adapts code from the [solmate nft](./solmate-nft.md) tutorial. If you haven't completed that tutorial yet, and are new to solidity, you may want to start with it first. Alternatively, if you have some familiarity with Docker and Solidity, you can use your own existing project and adjust accordingly. The full source code for both the NFT and the Docker stuff is available [here](https://github.com/dmfxyz/foundry-docker-tutorial).
+
+#####  This tutorial is for illustrative purposes only and provided on an as-is basis. The tutorial is not audited nor fully tested. No code in this tutorial should be used in a production environment.
+
+
+## Installation and Setup
+
+The only installation required to run this tutorial is Docker, and optionally, an IDE of your choice. 
+Follow the [Docker installation instructions](/getting-started/installation.html#using-within-docker).
+
+Once installed, you can download the latest release by running:  
+ `docker pull ghcr.io/gakonst/foundry:latest`
+
+ To keep future commands succinct, let's re-tag the image:  
+ `docker tag ghcr.io/gakonst/foundry:latest foundry:latest`
+
+Having forge/cast installed locally is not strictly required, but may be helpful for debugging. You can install them using [foundryup](/getting-started/installation.html#using-foundryup).
+
+Finally, to use any of the `cast` or `forge create` portions of this tutorial, you will need access to an Ethereum node. If you don't have your own node running (likely), you can use a Node as a service. We won't recommend a specific provider in this tutorial. A good place to start learning about Nodes-as-a-Service is [Ethereum's article](https://ethereum.org/en/developers/docs/nodes-and-clients/nodes-as-a-service/) on the subject.
+
+**For the rest of this tutorial, it is assumed that the RPC endpoint of your ethereum node is set like this**:    
+`export RPC_URL=<YOUR_RPC_URL>`
+
+
+## A tour around the Foundry docker image
+
+The docker image can be used in two primary ways:
+1. As an interface directly to forge and cast
+2. As a base image for building your own containerized test, build, and deployment tooling
+
+We will cover both, but let's start by taking a look at interfacing with foundry using docker. This is also a good test that your local installation worked!
+
+We can run any of the `cast` [commands](/reference/cast.html) against our docker image. Let's fetch the latest block information.
+```sh
+$> docker run foundry "cast block --rpc-url $RPC_URL latest"
+baseFeePerGas        "0xb634241e3"
+difficulty           "0x2e482bdf51572b"
+extraData            "0x486976656f6e20686b"
+gasLimit             "0x1c9c380"
+gasUsed              "0x652993"
+hash                 "0x181748772da2f968bcc91940c8523bb6218a7d57669ded06648c9a9fb6839db5"
+logsBloom            "0x406010046100001198c220108002b606400029444814008210820c04012804131847150080312500300051044208430002008029880029011520380060262400001c538d00440a885a02219d49624aa110000003094500022c003600a00258009610c410323580032000849a0408a81a0a060100022505202280c61880c80020e080244400440404520d210429a0000400010089410c8408162903609c920014028a94019088681018c909980701019201808040004100000080540610a9144d050020220c10a24c01c000002005400400022420140e18100400e10254926144c43a200cc008142080854088100128844003010020c344402386a8c011819408"
+miner                "0x1ad91ee08f21be3de0ba2ba6918e714da6b45836"
+mixHash              "0xb920857687476c1bcb21557c5f6196762a46038924c5f82dc66300347a1cfc01"
+nonce                "0x1ce6929033fbba90"
+number               "0xdd3309"
+parentHash           "0x39c6e1aa997d18a655c6317131589fd327ae814ef84e784f5eb1ab54b9941212"
+receiptsRoot         "0x4724f3b270dcc970f141e493d8dc46aeba6fffe57688210051580ac960fe0037"
+sealFields           []
+sha3Uncles           "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+size                 "0x1d6bb"
+stateRoot            "0x0d4b714990132cf0f21801e2931b78454b26aad706fc6dc16b64e04f0c14737a"
+timestamp            "0x6246259b"
+totalDifficulty      "0x9923da68627095fd2e7"
+transactions         [...]
+uncles               []
+```
+
+
+If we're in a directory with some solidity [source code](github.com:dmfxyz/foundry-docker-tutorial), we can mount that directory into docker and use `forge` however we wish. For example:
+```sh
+$>  docker run -v $PWD:/app foundry "forge test --root /app --watch"
+installing solc version "0.8.13"
+Successfully installed solc 0.8.13
+No files changed, compilation skipped
+
+Running 10 tests for src/test/NFT.t.sol:NFTTest
+[PASS] testBalanceIncremented() (gas: 218772)
+[PASS] testFailMaxSupplyReached() (gas: 136282)
+[PASS] testFailMintToZeroAddress() (gas: 34558)
+[PASS] testFailNoMintPricePaid() (gas: 5503)
+[PASS] testFailUnSafeContractReceiver() (gas: 89918)
+[PASS] testMintPricePaid() (gas: 81273)
+[PASS] testNewMintOwnerRegistered() (gas: 192098)
+[PASS] testSafeContractReceiver() (gas: 273972)
+[PASS] testWithdrawalFailsAsNotOwner() (gas: 194434)
+[PASS] testWithdrawalWorksAsOwner() (gas: 223174)
+Test result: ok. 10 passed; 0 failed; finished in 4.73ms
+```
+You can see our code was compiled and tested entirely within the container. Also, since we passed the `--watch` option, the container will recompile the code whenever a change is detected.
+
+
+## Building a basic compiling and testing image
+Let's see how we can use the Foundry docker image as a base for using our own, more complicated Docker image. The high level goals are:
+1. Build The Code
+2. Test The Code
+
+We'll start with a simple `Dockerfile` that accomplishes these two goals:
+```docker
+# Use the latest foundry image
+FROM ghcr.io/gakonst/foundry
+
+# Copy our source code into the container
+WORKDIR /app
+
+# Build and test the source code
+COPY . .
+RUN forge build
+RUN forge test
+```
+You can build this docker image and see forge build and run the tests:  
+```sh
+docker build --no-cache --progress=plain .
+```
+
+Now, what happens if one of the tests failed? Modify `src/test/NFT.t.sol` as you please to make one of the tests fail. Try to build image again.
+
+```sh
+$> docker build --no-cache --progress=plain .
+<...>
+#9 0.522 Failed tests:
+#9 0.522 [FAIL. Reason: Ownable: caller is not the owner] testWithdrawalFailsAsNotOwner() (gas: 193917)
+#9 0.522
+#9 0.522 Encountered a total of 1 failing tests, 9 tests succeeded
+------
+error: failed to solve: executor failed running [/bin/sh -c forge test]: exit code: 1
+```
+Our image failed to build because our tests failed! This is actually a nice property, because it means if we have a Docker image that successfully built (and therefore is available for use), we know the code inside the image passed the tests.*
+##### *Of course, chain of custody of your docker images is important to ensure this is the case. Docker layer hashes can be very useful for verification. In a production environment, consider [signing your docker images](https://docs.docker.com/engine/security/trust/#:~:text=To%20sign%20a%20Docker%20Image,the%20local%20Docker%20trust%20repository).
+
+## Building a deployer iamge
+Now, we'll move on to a bit more of an advanced Dockerfile. Let's define a entrypoint that allows us to deploy our code by using the built (and tested!) image. We can target the Rinkeby testnet first.
+
+```docker
+ Use the latest foundry image
+FROM ghcr.io/gakonst/foundry
+
+# Copy our source code into the container
+WORKDIR /app
+
+# Build and test the source code
+COPY . .
+RUN forge build
+RUN forge test
+
+# Set the entrypoint to the forge deployment command
+ENTRYPOINT ["forge", "create"]
+```
+Let's build the image, this time giving it a name:
+```sh
+$> docker build --no-cache --progress=plain -t nft-deployer .
+```
+
+Here's how we can use our docker image to deploy:
+```sh
+$> docker run nft-deployer --rpc-url $RPC_URL --constructor-args "ForgeNFT" "FNFT" "https://ethereum.org" --private-key $PRIVATE_KEY ./src/NFT.sol:NFT
+No files changed, compilation skipped
+Deployer: 0x496e09fcb240c33b8fda3b4b74d81697c03b6b3d
+Deployed to: 0x23d465eaa80ad2e5cdb1a2345e4b54edd12560d3
+Transaction hash: 0xf88c68c4a03a86b0e7ecb05cae8dea36f2896cd342a6af978cab11101c6224a9
+```
+
+We've just built, tested, and deployed our contract entirely within a docker container! This tutorial was intended to target testnet, but you can run the exact same Docker image targeting mainnet and be confident that the same code is being deployed by the same tooling.
+
+## Why is this useful?
+Docker is about portability, re-producibility, and environment invariance. This means you can be less concerned about unexpected changes when you switch between environments, networks, developers, etc. Here are a few basic examples of why **I** like to use Docker images for smart contract deployment:
+
+* Reduces overhead of ensuring system level dependencies match between deployment environments (e.g. does your production runner always have the same version of `forge` as your dev runner?)
+* Increases confidence that code has been tested prior to deployment and has not been altered (e.g. if, in the above image, your code re-compiles on deployment, that's a major red flag).
+* Eases pain points around segregation of duties: people with your mainnet credentials do not need to ensure they have the latest compiler, codebase, etc. It's easy to ensure that the docker deploy image someone ran in testnet is identical to the one targeting mainnet.
+* At the risk of sounding web2, Docker is an accepted standard on virtually all public cloud providers. It makes it easy to schedule jobs, tasks, etc that need to interact with the blockchain.
+
+


### PR DESCRIPTION
This is a write-up of the Docker installation instructions and a walkthrough of how to use foundry within docker. It covers:

- Basic Installation
- Direct Interfacing w/ `forge` and `cast` through Docker
- Live developing in Docker using `--watch`
- Building custom images on top of the Foundry image

There will likely be more to add later, but this covers a good first portion.