### PR TITLE
debugging complex functions

### DIFF
--- a/src/forge/debugger.md
+++ b/src/forge/debugger.md
@@ -11,16 +11,12 @@ $ forge run --debug $FILE --sig $FUNC
 Where `$FILE` is the path to the contract you want to debug, and `$FUNC` is the signature of the function you want to debug. For example:
 
 ```sh
-$ forge run --debug src/MyContract.sol --sig "someFunction()"
+$ forge run --debug src/SomeContract.sol --sig "myFunc(uint256,string)" 123 "hello"
 ```
+
+Additionally, test files can also be debugged in the same way.
 
 If your source file contains more than one contract, specify the contract you want to debug using the `--target-contract` flag.
-
-To debug a more complex funciton, for instance one that requires additional parameters or uses a variable set in the constructor, you can simply write a test for it and debug that
-
-```sh
-$ forge run --debug src/test/MyContract.t.sol --sig "testSomeFunction()"
-```
 
 ### Debugger layout
 

--- a/src/forge/debugger.md
+++ b/src/forge/debugger.md
@@ -16,6 +16,12 @@ $ forge run --debug src/MyContract.sol --sig "someFunction()"
 
 If your source file contains more than one contract, specify the contract you want to debug using the `--target-contract` flag.
 
+To debug a more complex funciton, for instance one that requires additional parameters or uses a variable set in the constructor, you can simply write a test for it and debug that
+
+```sh
+$ forge run --debug src/test/MyContract.t.sol --sig "testSomeFunction()"
+```
+
 ### Debugger layout
 
 ![An image of the debugger UI](../images/debugger.png)


### PR DESCRIPTION
I added a line on the debugger tab explaining how to debug more complex functions (ones with a constructor or need a certain state)

I found this not to be obvious when I first started using foundry so I thought it may be useful to someone in the future