### PR TITLE
style: indent solidity code snippets with 4 spaces

### DIFF
--- a/src/forge/cheatcodes.md
+++ b/src/forge/cheatcodes.md
@@ -11,36 +11,36 @@ Let's write a test for a smart contract that is only callable by its owner.
 pragma solidity ^0.8.0;
 
 contract OwnerUpOnly {
-  address public immutable owner;
-  uint256 public count;
+    address public immutable owner;
+    uint256 public count;
 
-  constructor() {
-    owner = msg.sender;
-  }
+    constructor() {
+        owner = msg.sender;
+    }
 
-  function increment() external {
-    require(
-      msg.sender == owner,
-      "only the owner can increment the count"
-    );
-    count++;
-  }
+    function increment() external {
+        require(
+            msg.sender == owner,
+            "only the owner can increment the count"
+        );
+      count++;
+    }
 }
 
 import "ds-test/test.sol";
 
 contract OwnerUpOnlyTest is DSTest {
-  OwnerUpOnly upOnly;
+    OwnerUpOnly upOnly;
 
-  function setUp() public {
-    upOnly = new OwnerUpOnly();
-  }
+    function setUp() public {
+        upOnly = new OwnerUpOnly();
+    }
 
-  function testIncrementAsOwner() public {
-    assertEq(upOnly.count(), 0);
-    upOnly.increment();
-    assertEq(upOnly.count(), 1);
-  }
+    function testIncrementAsOwner() public {
+        assertEq(upOnly.count(), 0);
+        upOnly.increment();
+        assertEq(upOnly.count(), 1);
+    }
 }
 ```
 
@@ -58,20 +58,20 @@ Let's make sure that someone who is definitely not the owner can't increment the
 
 ```solidity
 interface CheatCodes {
-  function prank(address) external;
+    function prank(address) external;
 }
 
 contract OwnerUpOnlyTest is DSTest {
-  CheatCodes cheats = CheatCodes(HEVM_ADDRESS);
-  OwnerUpOnly upOnly;
+    CheatCodes cheats = CheatCodes(HEVM_ADDRESS);
+    OwnerUpOnly upOnly;
 
-  // setUp
-  // testIncrementAsOwner
+    // setUp
+    // testIncrementAsOwner
 
-  function testFailIncrementAsNotOwner() public {
-    cheats.prank(address(0));
-    upOnly.increment();
-  }
+    function testFailIncrementAsNotOwner() public {
+        cheats.prank(address(0));
+        upOnly.increment();
+    }
 }
 ```
 
@@ -110,8 +110,8 @@ To be sure in the future, let's make sure that we reverted because we are not th
 
 ```solidity
 interface CheatCodes {
-  function prank(address) external;
-  function expectRevert(bytes calldata) external;
+    function prank(address) external;
+    function expectRevert(bytes calldata) external;
 }
 
 contract OwnerUpOnlyTest is DSTest {

--- a/src/forge/deploying.md
+++ b/src/forge/deploying.md
@@ -7,6 +7,7 @@ Forge can deploy only one contract at a time.
 To deploy a contract, you must provide a RPC URL (env: `ETH_RPC_URL`) and the private key of the account that will deploy the contract.
 
 To deploy `MyContract` to a network:
+
 ```sh
 $ forge create --rpc-url <your_rpc_url> --private-key <your_private_key> src/MyContract.sol:MyContract
 compiling...
@@ -23,6 +24,7 @@ Use the `--constructor-args` flag to pass arguments to the constructor:
 ```solidity
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
+
 import {ERC20} from "solmate/tokens/ERC20.sol";
 
 contract MyToken is ERC20 {
@@ -42,6 +44,7 @@ $ forge create --rpc-url <your_rpc_url> --constructor-args "ForgeUSD" "FUSD" 18 
 ```
 
 ## Verifying
+
 You can verify a contract on Etherscan with the `forge verify-contract` command.
 
 You must provide:
@@ -87,6 +90,7 @@ Contract successfully verified.
 ### Troubleshooting
 
 ##### `Invalid character 'x' at position 1`
+
 Make sure the private key string does not begin with `0x`.
 
 ##### `EIP-1559 not activated`
@@ -99,10 +103,13 @@ Make sure the passed arguments are of correct type.
 Make sure the private key is correct.
 
 ##### `Compiler version commit for verify`
-If you want to check the exact commit you are running locally, try: ` ~/.svm/0.x.y/solc-0.x.y --version` where `x` and `y` are major and minor version numbers respectively.  The output of this will be something like:
+If you want to check the exact commit you are running locally, try: ` ~/.svm/0.x.y/solc-0.x.y --version` where `x` and
+`y` are major and minor version numbers respectively.  The output of this will be something like:
+
 ```ignore
 solc, the solidity compiler commandline interface
 Version: 0.8.12+commit.f00d7308.Darwin.appleclang
 ```
+
 Note: You cannot just paste the entire string "0.8.12+commit.f00d7308.Darwin.appleclang" as the argument for the compiler-version.  But you can use the 8 hex digits of the commit to look up exactly what you should copy and paste from [compiler version](https://etherscan.io/solcversions).
 

--- a/src/forge/fuzz-testing.md
+++ b/src/forge/fuzz-testing.md
@@ -11,32 +11,32 @@ Let's examine what that means by writing a unit test, finding the general proper
 pragma solidity ^0.8.0;
 
 contract Safe {
-  receive() external payable {}
+    receive() external payable {}
 
-  function withdraw() external {
-    payable(msg.sender).transfer(address(this).balance);
-  }
+    function withdraw() external {
+        payable(msg.sender).transfer(address(this).balance);
+    }
 }
 
 import "ds-test/test.sol";
 
 contract SafeTest is DSTest {
-  Safe safe;
+    Safe safe;
 
-  // Needed so the test contract itself can receive ether
-  receive() external payable {}
+    // Needed so the test contract itself can receive ether
+    receive() external payable {}
 
-  function setUp() public {
-    safe = new Safe();
-  }
+    function setUp() public {
+        safe = new Safe();
+    }
 
-  function testWithdraw() public {
-    payable(address(safe)).transfer(1 ether);
-    uint256 preBalance = address(this).balance;
-    safe.withdraw();
-    uint256 postBalance = address(this).balance;
-    assertEq(preBalance + 1 ether, postBalance);
-  }
+    function testWithdraw() public {
+        payable(address(safe)).transfer(1 ether);
+        uint256 preBalance = address(this).balance;
+        safe.withdraw();
+        uint256 postBalance = address(this).balance;
+        assertEq(preBalance + 1 ether, postBalance);
+    }
 }
 ```
 
@@ -58,17 +58,17 @@ Forge will run any test that takes at least one parameter as a property-based te
 
 ```solidity
 contract SafeTest is DSTest {
-  // safe
-  // receive
-  // setUp
+    // safe
+    // receive
+    // setUp
 
-  function testWithdraw(uint256 amount) public {
-    payable(address(safe)).transfer(amount);
-    uint256 preBalance = address(this).balance;
-    safe.withdraw();
-    uint256 postBalance = address(this).balance;
-    assertEq(preBalance + amount, postBalance);
-  }
+    function testWithdraw(uint256 amount) public {
+        payable(address(safe)).transfer(amount);
+        uint256 preBalance = address(this).balance;
+        safe.withdraw();
+        uint256 postBalance = address(this).balance;
+        assertEq(preBalance + amount, postBalance);
+    }
 }
 ```
 
@@ -92,13 +92,13 @@ The default amount of ether that the test contract is given is `2**96 wei` (as i
 
 ```solidity
 contract SafeTest is DSTest {
-  // safe
-  // receive
-  // setUp
+    // safe
+    // receive
+    // setUp
 
-  function testWithdraw(uint96 amount) public {
-    // snip
-  }
+    function testWithdraw(uint96 amount) public {
+        // snip
+    }
 }
 ```
 
@@ -116,8 +116,8 @@ You may want to exclude certain cases using the [`assume`](../reference/cheatcod
 
 ```solidity
 function testWithdraw(uint96 amount) public {
-  cheats.assume(amount > 0.1 ether)
-  // snip
+    cheats.assume(amount > 0.1 ether)
+    // snip
 }
 ```
 

--- a/src/reference/cheatcodes.md
+++ b/src/reference/cheatcodes.md
@@ -358,7 +358,7 @@ To use `expectRevert` with a custom [error type](https://docs.soliditylang.org/e
 
 ```solidity
 cheats.expectRevert(
-  abi.encodeWithSelector(MyContract.CustomError.selector, 1, 2)
+    abi.encodeWithSelector(MyContract.CustomError.selector, 1, 2)
 );
 ```
 
@@ -377,7 +377,6 @@ function testLowLevelCallRevert() public {
     cheats.expectRevert(bytes("error message"));
     (bool status, ) = address(myContract).call(myCalldata);
     assertTrue(status, "expectRevert: call did not revert");
-
 }
 ```
 
@@ -470,16 +469,16 @@ For example:
 event Transfer(address indexed from, address indexed to, uint256 amount);
 
 function testERC20EmitsTransfer() public {
-  // Only `src` and `dst` are indexed in ERC20's `Transfer` event,
-  // so we specifically check topics 1 and 2 (topic 0 is always checked by default),
-  // as well as the data (`amount`).
-  cheats.expectEmit(true, true, false, true);
+    // Only `src` and `dst` are indexed in ERC20's `Transfer` event,
+    // so we specifically check topics 1 and 2 (topic 0 is always checked by default),
+    // as well as the data (`amount`).
+    cheats.expectEmit(true, true, false, true);
 
-  // We emit the event we expect to see.
-  emit MyToken.Transfer(address(this), address(1), 10);
+    // We emit the event we expect to see.
+    emit MyToken.Transfer(address(this), address(1), 10);
 
-  // We perform the call.
-  myToken.transfer(address(1), 10);
+    // We perform the call.
+    myToken.transfer(address(1), 10);
 }
 ```
 
@@ -489,15 +488,15 @@ Calls to other cheat codes before the final call are ignored, meaning we can als
 
 ```solidity
 function testERC20EmitsTransfer() public {
-  // The first two lines are the same as above.
-  cheats.expectEmit(true, true, false, true);
-  emit MyToken.Transfer(address(alice), address(1), 10);
+    // The first two lines are the same as above.
+    cheats.expectEmit(true, true, false, true);
+    emit MyToken.Transfer(address(alice), address(1), 10);
 
-  // Use the `prank` cheat code to impersonate a user.
-  cheats.prank(address(alice));
+    // Use the `prank` cheat code to impersonate a user.
+    cheats.prank(address(alice));
 
-  // We perform the call.
-  myToken.transfer(address(1), 10);
+    // We perform the call.
+    myToken.transfer(address(1), 10);
 }
 ```
 
@@ -507,18 +506,18 @@ We can also assert that multiple events are emitted in a single call. For exampl
 
 ```solidity
 function testERC20EmitsBatchTransfer() public {
-  // We declare multiple expected transfer events
-  for (uint256 i = 0; i < users.length; i++) {
-    cheats.expectEmit(true, true, true, true);
-    emit Transfer(address(this), users[i], 10);
-  }
+    // We declare multiple expected transfer events
+    for (uint256 i = 0; i < users.length; i++) {
+        cheats.expectEmit(true, true, true, true);
+        emit Transfer(address(this), users[i], 10);
+    }
 
-  // We also expect a custom `BatchTransfer(uint256 numberOfTransfers)` event.
-  cheats.expectEmit(false, false, false, false);
-  emit BatchTransfer(users.length);
+    // We also expect a custom `BatchTransfer(uint256 numberOfTransfers)` event.
+    cheats.expectEmit(false, false, false, false);
+    emit BatchTransfer(users.length);
 
-  // We perform the call.
-  myToken.batchTransfer(users, 10);
+    // We perform the call.
+    myToken.batchTransfer(users, 10);
 }
 ```
 
@@ -550,12 +549,12 @@ Mocked calls are in effect until [`clearMockedCalls`](#clearmockedcalls) is call
 
 ```solidity
 function testMockCall() public {
-  cheats.mockCall(
-    address(0),
-    abi.encodeWithSelector(MyToken.balanceOf.selector, address(1)),
-    abi.encode(10)
-  );
-  assertEq(IERC20(address(0)).balanceOf(address(1)), 10);
+    cheats.mockCall(
+        address(0),
+        abi.encodeWithSelector(MyToken.balanceOf.selector, address(1)),
+        abi.encode(10)
+    );
+    assertEq(IERC20(address(0)).balanceOf(address(1)), 10);
 }
 ```
 
@@ -563,15 +562,15 @@ function testMockCall() public {
 
 ```solidity
 function testMockCall() public {
-  cheats.mockCall(
-    address(0),
-    abi.encodeWithSelector(MyToken.balanceOf.selector),
-    abi.encode(10)
-  );
-  assertEq(IERC20(address(0)).balanceOf(address(1)), 10);
-  assertEq(IERC20(address(0)).balanceOf(address(2)), 10);
+    cheats.mockCall(
+        address(0),
+        abi.encodeWithSelector(MyToken.balanceOf.selector),
+        abi.encode(10)
+    );
+    assertEq(IERC20(address(0)).balanceOf(address(1)), 10);
+    assertEq(IERC20(address(0)).balanceOf(address(2)), 10);
 
-  // and so on..
+    // and so on..
 }
 ```
 

--- a/src/tutorials/solmate-nft.md
+++ b/src/tutorials/solmate-nft.md
@@ -32,23 +32,22 @@ import "solmate/tokens/ERC721.sol";
 import "openzeppelin-contracts/contracts/utils/Strings.sol";
 
 contract NFT is ERC721 {
-   uint256 public currentTokenId;
+    uint256 public currentTokenId;
 
-   constructor(
-       string memory _name,
-       string memory _symbol
-   ) ERC721(_name, _symbol) {
-   }
+    constructor(
+        string memory _name,
+        string memory _symbol
+    ) ERC721(_name, _symbol) {}
 
-   function mintTo(address recipient) public payable returns (uint256) {
-       uint256 newItemId = ++currentTokenId;
-       _safeMint(recipient, newItemId);
-       return newItemId;
-   }
+    function mintTo(address recipient) public payable returns (uint256) {
+        uint256 newItemId = ++currentTokenId;
+        _safeMint(recipient, newItemId);
+        return newItemId;
+    }
 
-   function tokenURI(uint256 id) public view virtual override returns (string memory) {
-       return Strings.toString(id);
-   }
+    function tokenURI(uint256 id) public view virtual override returns (string memory) {
+        return Strings.toString(id);
+    }
 }
 ```
 


### PR DESCRIPTION
The Solidity code snippets are inconsistent in the number of spaces they use for indenting.

Since the Solidity docs [recommend using 4 spaces](https://docs.soliditylang.org/en/v0.8.13/style-guide.html?highlight=4%20spaces#indentation), I changed all code snippets in the Foundry book to follow this recommendation.