### PR TITLE
Add private key arg to forge create command

### DIFF
--- a/src/tutorials/solmate-nft.md
+++ b/src/tutorials/solmate-nft.md
@@ -2,7 +2,7 @@
 
 This tutorial walk you through creating an OpenSea compatible NFT with Foundry and [Solmate](https://github.com/Rari-Capital/solmate/blob/main/src/tokens/ERC721.sol). A full implementation of this tutorial can be found [here](https://github.com/FredCoen/nft-tutorial).
 
-#####  This tutorial is for illustrative purposes only and provided on an as-is basis. The tutorial is not audited nor fully tested. No code in this tutorial should be used in a production environment.
+##### This tutorial is for illustrative purposes only and provided on an as-is basis. The tutorial is not audited nor fully tested. No code in this tutorial should be used in a production environment.
 
 
 
@@ -65,7 +65,7 @@ export PRIVATE_KEY=<Your wallets private key>
 
 Once set, you can deploy your NFT with Forge by running the below command while adding the relevant constructor arguments to the NFT contract:
 ```bash
-forge create NFT --rpc-url=$RPC_URL --constructor-args <name> <symbol>
+forge create NFT --rpc-url=$RPC_URL --private-key=$PRIVATE_KEY --constructor-args <name> <symbol>
 ```
 
 If successfully deployed, you will see the deploying wallet's address, the contract's address as well as the transaction hash printed to your terminal.


### PR DESCRIPTION
This PR adds the `--private-key` arg to the `forge create` command in the example.

Without the private key arg, the command fails, as expected, since it needs the private key in order to deploy the contract. Here is the error shown when one is not provided:

```
Error:
   0: error accessing local wallet, did you set a private key, mnemonic or keystore? Run `cast send --help` or `forge create --help` and use the corresponding CLI flag to set your key via --private-key, --mnemonic-path, --interactive, --trezor or --ledger. Alternatively, if you're using a local node with unlocked accounts, set the `ETH_FROM` environment variable to the address of the account you want to use
```

My editor removed an empty space, I kept it and included it as part of the same commit, but I'm happy to either completely remove it and not change it, or remove it as part of another commit.